### PR TITLE
use dynamic viewport units for better iPad experience

### DIFF
--- a/src/lib/ui/layouts/PageLayout.svelte
+++ b/src/lib/ui/layouts/PageLayout.svelte
@@ -12,7 +12,8 @@
 	.layout-page {
 		display: grid;
 		grid-template-rows: auto 1fr auto;
-		min-height: 100vh;
+		height: 100vh;
+		height: 100dvh;
 	}
 
 	main {

--- a/src/styles.css
+++ b/src/styles.css
@@ -53,10 +53,10 @@
 }
 
 body {
-	min-height: 100vh;
+	min-height: 100dvh;
 	margin: 0;
 	background-color: var(--color-bg-light);
-	background-size: 100vw 100vh;
+	background-size: 100dvw 100dvh;
 }
 
 h1,


### PR DESCRIPTION
This change fixes an slightly obnoxious issue with the page sizing on iOS (iPad)