### PR TITLE
feat: add member notes popover

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -25,6 +25,9 @@ module.exports = {
 			parser: 'svelte-eslint-parser',
 			parserOptions: {
 				parser: '@typescript-eslint/parser'
+			},
+			rules: {
+				'svelte/no-at-html-tags': 'warn'
 			}
 		}
 	],

--- a/src/lib/ui/ActivitySelect.svelte
+++ b/src/lib/ui/ActivitySelect.svelte
@@ -28,25 +28,17 @@
 
 {#if activeMember?.id}
 	<form id={formId} method="post" action="?/logVisit" use:enhance>
-		<div class="activity-title">Select {displayName}'s Activity</div>
+		<div class="activity-title">Select <b>{displayName}</b>'s activity for today</div>
 		<div class="activity-container">
 			{#each purposes as purpose}
 				<button
-					class="btn btn-primary"
+					class="primary option"
 					on:click={() => {
 						selectedPurpose = purpose;
 					}}
 					>{purpose.name}
 				</button>
 			{/each}
-		</div>
-
-		<div class="selected-activity">
-			<div>
-				You've selected: <span class="highlight">{activeVisit ? activeVisit.purpose.name : ''}</span
-				>
-			</div>
-			<div>for {displayName}</div>
 		</div>
 		<input type="hidden" name="memberId" value={activeMember.id} />
 		<input type="hidden" name="purposeId" value={selectedPurpose ? selectedPurpose.id : ''} />
@@ -58,33 +50,18 @@
 
 <style>
 	.activity-title {
-		margin: 40px 0px;
+		margin-bottom: 40px;
 	}
 
 	.activity-container {
 		display: flex;
 		flex-direction: column;
-		width: 100%;
-		max-width: 48rem;
-		flex: 0.2;
-		justify-content: center;
-		margin: 0 auto;
+		max-width: 100%;
+		gap: 0.5rem;
 	}
 
-	button {
+	.option {
+		/* makes the option buttons slightly smaller than usual */
 		min-height: 40px;
-		margin: 5px 0px;
-	}
-
-	.selected-activity {
-		display: flex;
-		flex-direction: column;
-		margin: 30px 0px;
-	}
-
-	.highlight {
-		margin-left: 0.5em;
-		font-size: larger;
-		font-weight: bold;
 	}
 </style>

--- a/src/lib/ui/Modal.svelte
+++ b/src/lib/ui/Modal.svelte
@@ -22,15 +22,15 @@
 
 <div class="modal-container">
 	<dialog bind:this={dialog} on:close={handleClose}>
-		<div class="close-x"><button on:click={handleClose}> X </button></div>
+		<button class="close" on:click={handleClose}>&times;</button>
 		<div class="content">
 			<slot />
 		</div>
 
 		<span class="button-container">
 			<slot name="buttons">
-				<button class="btn btn-primary">Cancel</button>
-				<button class="btn btn-primary" on:click={handleClose}>Confirm</button>
+				<button class="primary">Cancel</button>
+				<button class="primary" on:click={handleClose}>Confirm</button>
 			</slot>
 		</span>
 	</dialog>
@@ -38,17 +38,28 @@
 
 <style>
 	dialog {
+		position: relative;
 		background: var(--color-bg-light);
+		border: 0 none;
+		border-radius: var(--border-radius, 6px);
+		padding: 1rem;
+
+		&::backdrop {
+			background-color: rgba(0, 0, 0, 0.5);
+		}
 	}
 
-	.close-x {
-		display: flex;
-		justify-content: flex-end;
-	}
-
-	.close-x button {
-		padding: 6px 12px;
+	.close {
+		position: absolute;
+		z-index: 1;
+		right: 1rem;
+		top: 0.5rem;
 		min-height: 40px;
+		min-width: 40px;
+		padding: 0;
+		background-color: transparent;
+		font-size: 1.5em;
+		transform: translate(1rem, -0.25rem);
 	}
 
 	.content {

--- a/src/lib/ui/TopNav.svelte
+++ b/src/lib/ui/TopNav.svelte
@@ -82,6 +82,10 @@
 		transition: color 0.2s linear;
 	}
 
+	[aria-current='page'] {
+		color: rgb(var(--color-primary));
+	}
+
 	@media (hover) {
 		a:hover {
 			color: rgb(var(--color-primary));

--- a/src/routes/(shop)/+page.svelte
+++ b/src/routes/(shop)/+page.svelte
@@ -75,7 +75,11 @@
 			{#each filteredMemeberList as member}
 				<div class="button-group">
 					{#if member.status === 'suspended' || member.status === 'banned' || member.notes}
-						<button class="primary status" disabled={signedInMembers.has(member.id)}>
+						<button
+							class="primary status"
+							class:unavailable={signedInMembers.has(member.id)}
+							popovertarget={`membernotes-${member.id}`}
+						>
 							{#if member.status === 'suspended'}
 								<Exclamation />
 							{:else if member.status === 'banned'}
@@ -101,6 +105,29 @@
 						<ClipboardEditOutline />
 						<span class="visually-hidden">Edit Member</span>
 					</button>
+				</div>
+
+				<div id={`membernotes-${member.id}`} popover="auto" role="dialog">
+					<div class="notes">
+						<div class="notes-title">{getDisplayName(member)}</div>
+						{#if member.status === 'suspended'}
+							<span class="note-icon">
+								<Exclamation />
+							</span>
+							<span>This member is currently suspended</span>
+						{:else if member.status === 'banned'}
+							<span class="note-icon">
+								<AlertOctagon />
+							</span>
+							<span>This member is currently banned</span>
+						{/if}
+						{#if member.notes}
+							<span class="note-icon">
+								<QuestionMark />
+							</span>
+							<div>{@html member.notes}</div>
+						{/if}
+					</div>
 				</div>
 			{/each}
 		{/if}
@@ -209,7 +236,51 @@
 	.button-group .edit {
 		flex: 0 1 content;
 	}
-	.button-group .activity:not(.status + *) {
-		padding-inline-start: 4.25rem;
+	.button-group:not(:has(.status)) .activity::before {
+		content: '';
+		width: 3.2rem;
+	}
+
+	[popover] {
+		position: absolute;
+		top: 4rem;
+		bottom: auto;
+		margin: auto;
+		min-width: 400px;
+		width: 24rem;
+		max-width: 100%;
+		opacity: 0;
+		padding: 0;
+		transition:
+			opacity 0.3s,
+			display 0.3s allow-discrete;
+		border-radius: var(--border-radius, 6px);
+	}
+
+	[popover]:popover-open {
+		opacity: 1;
+	}
+
+	.notes {
+		display: grid;
+		grid-template-columns: min-content 1fr;
+		align-items: center;
+		gap: 1em 0.5em;
+		font-size: 1.2rem;
+		padding: 1rem;
+		background: var(--color-bg-dark);
+		color: var(--color-text-light);
+	}
+
+	.notes-title {
+		grid-column: span 2;
+		text-align: center;
+		justify-self: center;
+		font-size: 0.6em;
+		font-weight: bold;
+	}
+
+	.note-icon {
+		justify-self: end;
 	}
 </style>


### PR DESCRIPTION
This PR adds the ability to see the member notes from the activity selection and also fixes up some of the Modal styles

<img width="600" alt="Screenshot 2024-07-22 at 5 40 59 PM" src="https://github.com/user-attachments/assets/e13a8da6-1503-4a10-8825-e7036eb721b1">
<img width="600" alt="Screenshot 2024-07-22 at 5 40 39 PM" src="https://github.com/user-attachments/assets/ee56cdc1-3542-4725-a184-19796bd8f77b">
<img width="600" alt="Screenshot 2024-07-22 at 5 41 08 PM" src="https://github.com/user-attachments/assets/29e8a909-fe41-412a-981c-adca63a1540d">
