### PR TITLE
fix: make header logo link clickable again

### DIFF
--- a/src/lib/ui/Header.svelte
+++ b/src/lib/ui/Header.svelte
@@ -1,9 +1,8 @@
 <header>
+	<slot />
 	<div class="logo">
 		<slot name="logo" />
 	</div>
-
-	<slot />
 </header>
 
 <style>

--- a/src/routes/(shop)/+layout.svelte
+++ b/src/routes/(shop)/+layout.svelte
@@ -16,8 +16,8 @@
 
 <PageLayout>
 	<Header slot="header">
-		<TopNav {navItems} />
 		<Logo {logoUrl} {shopName} slot="logo" />
+		<TopNav {navItems} />
 	</Header>
 
 	<slot />


### PR DESCRIPTION
Logo link was not clickable. this PR fixes that



https://github.com/user-attachments/assets/0840e92f-8f2c-428c-a7c6-1f95d35b5b3b


