### PR TITLE
Move notes inside activity select

### DIFF
--- a/src/lib/ui/ActivitySelect.svelte
+++ b/src/lib/ui/ActivitySelect.svelte
@@ -34,6 +34,7 @@
 {#if activeMember?.id}
 	<form id={formId} method="post" action="?/logVisit" use:enhance>
 		<div class="activity-title">Select <b>{displayName}</b>'s activity for today</div>
+		<slot />
 		<div class="activity-container">
 			{#each purposes as purpose}
 				<button
@@ -56,7 +57,7 @@
 
 <style>
 	.activity-title {
-		margin-bottom: 40px;
+		margin-bottom: 1rem;
 	}
 
 	.activity-container {

--- a/src/routes/(shop)/+page.svelte
+++ b/src/routes/(shop)/+page.svelte
@@ -79,26 +79,18 @@
 		{#if showList}
 			{#each filteredMemeberList as member}
 				<div class="button-group">
-					{#if member.status === 'suspended' || member.status === 'banned' || member.notes}
-						<button
-							class="primary status"
-							class:unavailable={signedInMembers.has(member.id)}
-							popovertarget={`membernotes-${member.id}`}
-						>
-							{#if member.status === 'suspended'}
-								<Exclamation />
-							{:else if member.status === 'banned'}
-								<AlertOctagon />
-							{:else if member.notes}
-								<QuestionMark />
-							{/if}
-						</button>
-					{/if}
 					<button
 						class="primary activity"
 						on:click={(event) => handleMemberSelect(event, member)}
 						disabled={signedInMembers.has(member.id)}
 					>
+						{#if member.status === 'suspended'}
+							<i class="icon warning"><Exclamation /></i>
+						{:else if member.status === 'banned'}
+							<i class="icon error"><AlertOctagon /></i>
+						{:else if member.notes}
+							<i class="icon"><QuestionMark /></i>
+						{/if}
 						{getDisplayName(member)}
 					</button>
 
@@ -110,29 +102,6 @@
 						<ClipboardEditOutline />
 						<span class="visually-hidden">Edit Member</span>
 					</button>
-				</div>
-
-				<div id={`membernotes-${member.id}`} popover="auto" role="dialog">
-					<div class="notes">
-						<div class="notes-title">{getDisplayName(member)}</div>
-						{#if member.status === 'suspended'}
-							<span class="note-icon">
-								<Exclamation />
-							</span>
-							<span>This member is currently suspended</span>
-						{:else if member.status === 'banned'}
-							<span class="note-icon">
-								<AlertOctagon />
-							</span>
-							<span>This member is currently banned</span>
-						{/if}
-						{#if member.notes}
-							<span class="note-icon">
-								<QuestionMark />
-							</span>
-							<div>{@html member.notes}</div>
-						{/if}
-					</div>
 				</div>
 			{/each}
 		{/if}
@@ -187,7 +156,27 @@
 			searchElement.value = '';
 			searchElement.dispatchEvent(new Event('input', { bubbles: true }));
 		}}
-	/>
+	>
+		<div class="member-notes">
+			{#if activeMember?.status === 'suspended'}
+				<div class="note warning">
+					<Exclamation />
+					<span>This member is currently suspended</span>
+				</div>
+			{:else if activeMember?.status === 'banned'}
+				<div class="note error">
+					<AlertOctagon />
+					<span>This member is currently banned</span>
+				</div>
+			{/if}
+			{#if activeMember?.notes}
+				<div class="note">
+					<QuestionMark />
+					<div>{@html activeMember.notes}</div>
+				</div>
+			{/if}
+		</div>
+	</ActivitySelect>
 	<div slot="buttons">
 		<button class="primary" on:click={handleClose}>Cancel</button>
 	</div>
@@ -237,55 +226,49 @@
 		border-collapse: collapse;
 	}
 
-	.button-group .status,
+	.button-group .icon {
+		color: hsl(from rgb(var(--text-color-light)) h s l / 0.5);
+	}
+
+	.button-group .icon.warning {
+		color: hsl(from var(--color-warning) h calc(s + 10) calc(l + 10) / 1);
+	}
+
+	.button-group .icon.error {
+		color: hsl(from var(--color-error) h calc(s + 10) calc(l + 10) / 1);
+	}
+
 	.button-group .edit {
 		flex: 0 1 content;
 	}
-	.button-group:not(:has(.status)) .activity::before {
-		content: '';
-		width: 3.2rem;
-	}
 
-	[popover] {
-		position: absolute;
-		top: 4rem;
-		bottom: auto;
-		margin: auto;
-		min-width: 400px;
-		width: 24rem;
-		max-width: 100%;
-		opacity: 0;
-		padding: 0;
-		transition:
-			opacity 0.3s,
-			display 0.3s allow-discrete;
-		border-radius: var(--border-radius, 6px);
-	}
+	.member-notes {
+		display: flex;
+		flex-direction: column;
+		margin-bottom: 1rem;
 
-	[popover]:popover-open {
-		opacity: 1;
-	}
+		& > .note {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			gap: 0.5rem;
+			padding: 1rem;
+			background-color: hsl(from var(--color-bg-light) h s calc(l - 10));
 
-	.notes {
-		display: grid;
-		grid-template-columns: min-content 1fr;
-		align-items: center;
-		gap: 1em 0.5em;
-		font-size: 1.2rem;
-		padding: 1rem;
-		background: var(--color-bg-dark);
-		color: var(--color-text-light);
-	}
+			& > *:first-child {
+				min-width: 1.2rem;
+			}
 
-	.notes-title {
-		grid-column: span 2;
-		text-align: center;
-		justify-self: center;
-		font-size: 0.6em;
-		font-weight: bold;
-	}
+			&.error {
+				background-color: var(--color-error, rgb(220 20 60));
+				color: var(--text-color-light, white);
+			}
 
-	.note-icon {
-		justify-self: end;
+			&.warning {
+				background-color: var(--color-warning, rgb(167 127 6));
+				color: var(--text-color-light, white);
+				padding: 1rem;
+			}
+		}
 	}
 </style>

--- a/src/shop_config.ts
+++ b/src/shop_config.ts
@@ -30,6 +30,9 @@ export const theme: Record<string, string> = {
 	'color-primary': `64, 117, 166 ` /* #4075a6 */,
 	'color-secondary': `64, 117, 166` /* #40A6A4 */,
 	'color-neutral': `250, 250, 250`,
+	'color-success': 'rgb(15 186 129)',
+	'color-warning': 'rgb(167 127 6)',
+	'color-error': 'rgb(220 20 60)',
 	/* accent */
 	'color-accent': `#a348e9`,
 	'color-accent-subtle': `#e9ecef`,

--- a/src/styles.css
+++ b/src/styles.css
@@ -186,6 +186,19 @@ button:focus:not(:focus-visible) {
 	outline: none;
 }
 
+button:has(.icon) {
+	justify-content: space-between;
+
+	&::after {
+		content: '';
+	}
+}
+
+button > .icon {
+	display: inline-block;
+	line-height: 0.5;
+}
+
 .btn-primary,
 button.primary {
 	background-color: hsl(from rgb(var(--color-primary)) h s l / 0.8);


### PR DESCRIPTION
Move the notes into the Activity Selection Modal

This PR

- removes the extra button for notes/status
- displays the notes in the activity selector
- adds some colour to the icons  and notes for more attention grabbing behaviour
- adds 3 color settings to the theme
  - `color-success`, `color-warning` and `color-error`

https://github.com/user-attachments/assets/36e0ca0b-7ae3-49a0-a407-62a2dd3d8953


## Before
<img width="1003" alt="Screenshot 2024-07-26 at 1 06 05 PM" src="https://github.com/user-attachments/assets/8c90d7bb-4c22-4f2a-a65a-2f6bb8892468">

## After

<img width="1030" alt="Screenshot 2024-07-26 at 1 21 19 PM" src="https://github.com/user-attachments/assets/5867359a-fcf1-47a5-9dc4-4fce1ebcdd7c">


<img width="641" alt="Screenshot 2024-07-26 at 12 57 36 PM" src="https://github.com/user-attachments/assets/13d99a1e-8ee7-455a-803e-6df93fc4d54e">

<img width="230" alt="Screenshot 2024-07-26 at 12 59 47 PM" src="https://github.com/user-attachments/assets/4e4e8195-3055-4eb4-8a07-1a35cacc0cdb">

<img width="230" alt="Screenshot 2024-07-26 at 12 57 44 PM" src="https://github.com/user-attachments/assets/57e6e881-58a9-4e6a-8b5d-735744fdd36b">

<img width="230" alt="Screenshot 2024-07-26 at 12 57 57 PM" src="https://github.com/user-attachments/assets/9d47aedd-6db5-4d69-a204-4a65fd8e9a78">

