### PR TITLE
add wavier and guidelines to settings dashboard with source file notes

### DIFF
--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 	import { shopConfig, theme } from '../../../shop_config';
 	import { camelCaseToWords } from '$lib/ui/utils';
+	import LiabilityWaiver from '$lib/ui/LiabilityWaiver.svelte';
+	import MemberRightsAndGuidelines from '$lib/ui/MemberRightsAndGuidelines.svelte';
 </script>
 
 <h2>Shop Config</h2>
+<small>(Update Config settings in src/shop_config.ts)</small>
 <table class="settings-list">
 	{#each Object.keys(shopConfig) as setting}
 		<tr>
@@ -14,6 +17,7 @@
 </table>
 
 <h2>Shop Theme</h2>
+<small>(Update Theme settings in src/shop_config.ts)</small>
 <table class="theme-list">
 	{#each Object.keys(theme) as style}
 		<tr>
@@ -23,7 +27,17 @@
 	{/each}
 </table>
 
+<h3>(Update Liability Waiver markup content in src/lib/ui/LiabilityWaiver.svelte)</h3>
+
+<LiabilityWaiver />
+
+<h3>
+	(Update Member Rights & Guidelines markup content in src/lib/ui/MemberRightsAndGuidelines.svelte)
+</h3>
+<MemberRightsAndGuidelines />
+
 <style>
+	.theme-list,
 	.settings-list {
 		margin-top: 1rem;
 	}
@@ -38,6 +52,11 @@
 	}
 
 	h2 {
+		margin-top: 1.5em;
+		text-decoration: underline;
+	}
+
+	h3 {
 		margin-top: 1.5em;
 		text-decoration: underline;
 	}


### PR DESCRIPTION
This adds locations for shop config and theme settings, as well as shows the current wavier and guidelines content with directions to their source files. Will eventually be able to edit direct.

closes #95 