### PR TITLE
chore: switch the sveltekit adapter to auto for deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
 				"@iconify-json/mdi": "^1.1.66",
 				"@neoconfetti/svelte": "^1.0.0",
 				"@playwright/test": "^1.28.1",
-				"@sveltejs/adapter-auto": "^3.0.0",
+				"@sveltejs/adapter-auto": "^3.2.4",
 				"@sveltejs/adapter-node": "^5.2.0",
 				"@sveltejs/kit": "^2.0.0",
 				"@sveltejs/vite-plugin-svelte": "^3.0.0",
@@ -1211,11 +1211,13 @@
 			"optional": true
 		},
 		"node_modules/@sveltejs/adapter-auto": {
-			"version": "3.2.0",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-3.2.4.tgz",
+			"integrity": "sha512-a64AKYbfTUrVwU0xslzv1Jf3M8bj0IwhptaXmhgIkjXspBXhD0od9JiItQHchijpLMGdEDcYBlvqySkEawv6mQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"import-meta-resolve": "^4.0.0"
+				"import-meta-resolve": "^4.1.0"
 			},
 			"peerDependencies": {
 				"@sveltejs/kit": "^2.0.0"
@@ -1863,10 +1865,11 @@
 			"license": "MIT"
 		},
 		"node_modules/axios": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-			"integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+			"integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.6",
 				"form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"@iconify-json/mdi": "^1.1.66",
 		"@neoconfetti/svelte": "^1.0.0",
 		"@playwright/test": "^1.28.1",
-		"@sveltejs/adapter-auto": "^3.0.0",
+		"@sveltejs/adapter-auto": "^3.2.4",
 		"@sveltejs/adapter-node": "^5.2.0",
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from '@sveltejs/adapter-node';
+import adapter from '@sveltejs/adapter-auto';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */


### PR DESCRIPTION
We need the "auto" adapter for cloud deployments like Vercel or Netlify