### PR TITLE
refactor: use summary details elements for disclosure

### DIFF
--- a/src/additional-svelte-typings.d.ts
+++ b/src/additional-svelte-typings.d.ts
@@ -1,0 +1,12 @@
+declare namespace svelteHTML {
+	interface IntrinsicElements {
+		details: {
+			open?: boolean | undefined | null;
+			name?: string | undefined | null;
+
+			'bind:open'?: boolean | undefined | null;
+
+			'on:toggle'?: EventHandler<Event, HTMLDetailsElement> | undefined | null;
+		};
+	}
+}

--- a/src/lib/ui/Disclosure.svelte
+++ b/src/lib/ui/Disclosure.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+	export let open = false;
+	export let name: string | undefined | null = undefined;
+</script>
+
+<details bind:open {name}>
+	{#if $$slots.title && ((!$$slots['open-title'] && open) || (!$$slots['closed-title'] && !open))}
+		<summary>
+			<slot name="title"></slot>
+		</summary>
+	{/if}
+	{#if $$slots['open-title'] && open}
+		<summary>
+			<slot name="open-title"></slot>
+		</summary>
+	{/if}
+	{#if $$slots['closed-title'] && !open}
+		<summary>
+			<slot name="closed-title"></slot>
+		</summary>
+	{/if}
+	<div class="content">
+		<slot></slot>
+	</div>
+</details>
+
+<style>
+	summary {
+		list-style: none;
+		background-color: #777;
+		color: white;
+		cursor: pointer;
+		padding: 18px;
+		border: none;
+		text-align: center;
+		outline: none;
+		font-size: 15px;
+	}
+
+	details[open] summary {
+		background-color: #555;
+	}
+
+	@media (hover) {
+		summary:hover {
+			background-color: #555;
+		}
+	}
+
+	summary::-webkit-details-marker {
+		display: none;
+	}
+
+	summary::after {
+		content: ' +';
+	}
+
+	details[open] summary::after {
+		content: ' -';
+	}
+
+	summary:focus-visible {
+		outline: var(--color-accent) auto 1px;
+		outline: -webkit-focus-ring-color auto 1px;
+	}
+
+	details > .content {
+		display: block;
+		padding: 5px 18px;
+		background-color: #f1f1f1;
+	}
+
+	details::details-content {
+		display: block;
+		overflow: hidden;
+		block-size: calc-size(any, 0px);
+		transition-property: block-size, content-visibility;
+		transition-duration: 0.5s;
+		transition-behavior: allow-discrete;
+	}
+
+	details[open] > .content,
+	details[open]::details-content {
+		block-size: auto;
+	}
+</style>

--- a/src/lib/ui/LiabilityWaiver.svelte
+++ b/src/lib/ui/LiabilityWaiver.svelte
@@ -1,29 +1,12 @@
 <script lang="ts">
 	import { format } from 'date-fns';
+	import Disclosure from './Disclosure.svelte';
 
 	export let name: string = '';
 	export let requiresGuardian: boolean = false;
 	export let guardianName: string | null = '';
-	let isCollapsed = true;
-	$: collapseButtonText = isCollapsed ? 'Show Waiver +' : 'Hide Waiver -';
 
 	let waiverDate = format(Date.now(), 'LLLL dd, yyyy');
-
-	const toggleCollapsibleContent = (ev: MouseEvent) => {
-		const el = <HTMLElement>ev.target;
-		el?.classList.toggle('active');
-		const copyToCollapse = <HTMLElement>el.nextElementSibling;
-
-		if (copyToCollapse) {
-			if (copyToCollapse.style.maxHeight) {
-				copyToCollapse.style.maxHeight = '';
-				isCollapsed = true;
-			} else {
-				copyToCollapse.style.maxHeight = copyToCollapse.scrollHeight + 'px';
-				isCollapsed = false;
-			}
-		}
-	};
 </script>
 
 <div class="wavier-container">
@@ -36,8 +19,9 @@
 		***Children under the age of 13 must have guardian supervision when participating in BCBC
 		activities and events.
 	</small>
-	<button class="collapsible" on:click={toggleCollapsibleContent}>{collapseButtonText}</button>
-	<div class="collapsible-content">
+	<Disclosure>
+		<span slot="title">Show Waiver</span>
+		<span slot="open-title">Hide Waiver</span>
 		<p>
 			The Bridge City Bicycle Co-operative (herein referred to as The BCBC and The Community) is a
 			nonprofit, community bicycle repair education and resource co-operative. We offer our members
@@ -70,7 +54,7 @@
 			whether the cause of the claims or liability arise from the negligence, acts or omissions of
 			me, a third party, or the Community.
 		</p>
-	</div>
+	</Disclosure>
 	<div class="wavier-signature">
 		<p>I {name} have read and agree to the above terms & conditions.</p>
 		<p>Date: {waiverDate}</p>
@@ -91,30 +75,5 @@
 	.signature {
 		font-style: italic;
 		font-weight: bold;
-	}
-
-	.collapsible {
-		background-color: #777;
-		color: white;
-		cursor: pointer;
-		padding: 18px;
-		width: 100%;
-		border: none;
-		text-align: left;
-		outline: none;
-		font-size: 15px;
-	}
-
-	.active,
-	.collapsible:hover {
-		background-color: #555;
-	}
-
-	.collapsible-content {
-		padding: 0 18px;
-		max-height: 0;
-		overflow: hidden;
-		transition: max-height 0.2s ease-out;
-		background-color: #f1f1f1;
 	}
 </style>

--- a/src/lib/ui/MemberRightsAndGuidelines.svelte
+++ b/src/lib/ui/MemberRightsAndGuidelines.svelte
@@ -1,28 +1,12 @@
 <script lang="ts">
 	import { format } from 'date-fns';
+	import Disclosure from './Disclosure.svelte';
 
 	export let name: string = '';
 	export let requiresGuardian: boolean = false;
 	export let guardianName: string | null = '';
-	let isCollapsed = true;
-	$: collapseButtonText = isCollapsed ? 'Show Guidelines +' : 'Hide Guidelines -';
 
 	let waiverDate = format(Date.now(), 'LLLL dd, yyyy');
-
-	const toggleCollapsibleContent = (ev: MouseEvent) => {
-		const el = <HTMLElement>ev.target;
-		el?.classList.toggle('active');
-		const content = <HTMLElement>el.nextElementSibling;
-		if (content) {
-			if (content.style.maxHeight) {
-				content.style.maxHeight = '';
-				isCollapsed = true;
-			} else {
-				content.style.maxHeight = content.scrollHeight + 'px';
-				isCollapsed = false;
-			}
-		}
-	};
 </script>
 
 <h2>Bridge City Bicycle Co-op - Member Rights and Respect Guidelines</h2>
@@ -31,8 +15,10 @@
 	towards education, empowerment and community-building. In order to do so we need your input and
 	support.
 </small>
-<button class="collapsible" on:click={toggleCollapsibleContent}>{collapseButtonText}</button>
-<div class="collapsible-content">
+<Disclosure>
+	<span slot="title">Show Guidelines</span>
+	<span slot="open-title">Hide Guidelines</span>
+
 	<h3>Member Privileges</h3>
 	<li>Access to the BCBC tools, stands and workspace</li>
 	<li>Access to friendly mechanical assistance and education when available</li>
@@ -89,7 +75,7 @@
 		so many ways to be a part of this community, regardless of whether or not you know how to change
 		a tire (yet!). Ask how you can help out!
 	</p>
-</div>
+</Disclosure>
 <div class="guidelines-signature">
 	<p>
 		I {name} (print full name) acknowledge that my Membership and privileges in the Bridge City Bicycle
@@ -112,30 +98,5 @@
 	.signature {
 		font-style: italic;
 		font-weight: bold;
-	}
-
-	.collapsible {
-		background-color: #777;
-		color: white;
-		cursor: pointer;
-		padding: 18px;
-		width: 100%;
-		border: none;
-		text-align: left;
-		outline: none;
-		font-size: 15px;
-	}
-
-	.active,
-	.collapsible:hover {
-		background-color: #555;
-	}
-
-	.collapsible-content {
-		padding: 0 18px;
-		max-height: 0;
-		overflow: hidden;
-		transition: max-height 0.2s ease-out;
-		background-color: #f1f1f1;
 	}
 </style>

--- a/src/lib/ui/index.ts
+++ b/src/lib/ui/index.ts
@@ -6,6 +6,7 @@ export { default as Logo } from './Logo.svelte';
 export { default as TopNav } from './TopNav.svelte';
 export { default as Modal } from './Modal.svelte';
 export { default as Message } from './Message.svelte';
+export { default as Disclosure } from './Disclosure.svelte';
 export { default as FilterDataList } from './FilterDataList.svelte';
 export { default as LiabilityWaiver } from './LiabilityWaiver.svelte';
 export { default as MemberRightsAndGuidelines } from './MemberRightsAndGuidelines.svelte';


### PR DESCRIPTION
This PR removes some custom JS and CSS for showing and hiding the Liability Waiver and Member and Respect Guidelines, in favour of the built-in no-js `<details>` and `<summary>` elements, wrapped up in a `Disclosure` component for styles and text swapping of the open and closed state (which does not work without JS).

Note: This change actually ends up removing the animation, but hopefully only temporarily as it does include standards based CSS to animate the `details/summary` elements, but they are not supported in browsers yet.  That being said the animation does work in Chrome Canary and will "just start working" once the new CSS is supported in the users browser.

Chrome Canary:

https://github.com/user-attachments/assets/381eb677-8e63-43f0-ad90-58b4f1e87be3
