### PR TITLE
feat: add hook that removes non-action URL query params with empty values

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,4 +1,8 @@
 import { sequence } from '@sveltejs/kit/hooks';
 import { authServerHookHandler } from '$lib/auth';
+import { redirectToClearEmptyUrlParamsHook } from '$lib/utils';
 
-export const handle = sequence(authServerHookHandler({ loginRoute: '/login' }));
+export const handle = sequence(
+	authServerHookHandler({ loginRoute: '/login' }),
+	redirectToClearEmptyUrlParamsHook
+);

--- a/src/lib/utils/url.ts
+++ b/src/lib/utils/url.ts
@@ -1,15 +1,30 @@
+import { redirect, type Handle } from '@sveltejs/kit';
+
 export const isEmpty = (value: unknown) => value === '' || value === null || value === undefined;
 
-export const hasEmptyUrlParams = (url: URL) => [...url.searchParams.values()].some(isEmpty);
+export const hasEmptyUrlParams = (url: URL) =>
+	[...url.searchParams.entries()].some(([key, value]) => !key.startsWith('/') && isEmpty(value));
 
 export const clearEmptyUrlParams = (url: URL) => {
 	const newUrl = new URL(url);
 
 	url.searchParams.forEach((value, key) => {
-		if (isEmpty(value)) {
+		if (!key.startsWith('/') && isEmpty(value)) {
 			newUrl.searchParams.delete(key);
 		}
 	});
 
 	return newUrl;
+};
+
+/**
+ * Removes empty URL parameters from the URL, by redirecting, but since
+ * sveltkit form actions can be empty URL params, we need to check if the
+ * URL params start with a slash and ignore those ones
+ */
+export const redirectToClearEmptyUrlParamsHook: Handle = ({ event, event: { url }, resolve }) => {
+	if (hasEmptyUrlParams(url)) {
+		redirect(307, clearEmptyUrlParams(url).toString());
+	}
+	return resolve(event);
 };

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -1,22 +1,17 @@
-import { error, redirect } from '@sveltejs/kit';
+import { error } from '@sveltejs/kit';
 import { members as membersService } from '$lib/server/db';
 import { toValidStartDate, toValidEndDate } from '$lib/server/utils/dates';
-import { hasEmptyUrlParams, clearEmptyUrlParams } from '$lib/utils';
 
 export const load = async ({ locals, url }) => {
 	if (!locals.user?.role?.includes('admin')) {
 		error(403, 'Not an admin');
-	}
-	if (hasEmptyUrlParams(url)) {
-		redirect(307, clearEmptyUrlParams(url).toString());
 	}
 
 	const startDate = url.searchParams.get('startDate') || '';
 	const endDate = url.searchParams.get('endDate') || '';
 	const startPage = url.searchParams.get('page') || '1';
 	const urlString = url.toString();
-	let page;
-	$: page = parseInt(startPage, 10);
+	const page = parseInt(startPage, 10);
 
 	const { membersList, totalPages } = await membersService.findByDate({
 		startDate: toValidStartDate(startDate),

--- a/src/routes/admin/activity/+page.server.ts
+++ b/src/routes/admin/activity/+page.server.ts
@@ -1,9 +1,8 @@
-import { error, redirect } from '@sveltejs/kit';
+import { error } from '@sveltejs/kit';
 import z from 'zod';
 import { message, superValidate, fail } from 'sveltekit-superforms';
 import { zod } from 'sveltekit-superforms/adapters';
 import { toValidStartDate, toValidEndDate } from '$lib/server/utils/dates';
-import { hasEmptyUrlParams, clearEmptyUrlParams } from '$lib/utils';
 
 import { visits as visitsService, purposes as purposesService } from '$lib/server/db';
 
@@ -11,16 +10,12 @@ export const load = async ({ locals, url }) => {
 	if (!locals.user?.role?.includes('admin')) {
 		error(403, 'Not an admin');
 	}
-	if (hasEmptyUrlParams(url)) {
-		redirect(307, clearEmptyUrlParams(url).toString());
-	}
 
 	const startDate = url.searchParams.get('startDate') ?? '';
 	const endDate = url.searchParams.get('endDate') ?? '';
 	const startPage = url.searchParams.get('page') || '1';
 	const urlString = url.toString();
-	let page;
-	$: page = parseInt(startPage, 10);
+	const page = parseInt(startPage, 10);
 
 	const { visitsList, totalPages } = await visitsService.findByDate({
 		startDate: toValidStartDate(startDate),

--- a/src/routes/admin/bikes/+page.server.ts
+++ b/src/routes/admin/bikes/+page.server.ts
@@ -1,22 +1,17 @@
-import { error, redirect } from '@sveltejs/kit';
+import { error } from '@sveltejs/kit';
 import { bikes as bikesService } from '$lib/server/db';
 import { toValidEndDate, toValidStartDate } from '$lib/server/utils/dates';
-import { hasEmptyUrlParams, clearEmptyUrlParams } from '$lib/utils';
 
 export const load = async ({ locals, url }) => {
 	if (!locals.user?.role?.includes('admin')) {
 		error(403, 'Not an admin');
-	}
-	if (hasEmptyUrlParams(url)) {
-		redirect(307, clearEmptyUrlParams(url).toString());
 	}
 
 	const startDate = url.searchParams.get('startDate') ?? '';
 	const endDate = url.searchParams.get('endDate') ?? '';
 	const startPage = url.searchParams.get('page') || '1';
 	const urlString = url.toString();
-	let page;
-	$: page = parseInt(startPage, 10);
+	const page = parseInt(startPage, 10);
 
 	const { bikesList, totalPages } = await bikesService.findByDate({
 		startDate: toValidStartDate(startDate),


### PR DESCRIPTION
This PR moves the `clearEmptyUrlParams` params  into a hook so it is done automatically for every request, instead of having to set it up on each load function