### PR TITLE
add pb_data and pb_migrations to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ node_modules
 /.svelte-kit
 /package
 
+#pocketbase
+/pb_data
+/pb_migrations
+
 # environment
 .env
 .env.*


### PR DESCRIPTION
Following the setup instructions would lead to having the db directories in the root of the project, so to prevent accidental commit of the data files I am adding  these directories to `.gitignore`